### PR TITLE
Omni: Set QS_TILE_PREFERENCES to main activity for qs tile long click

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
 
             <meta-data
                 android:name="android.app.shortcuts"


### PR DESCRIPTION
* Instead of openning system settings page
* Could be extended to opening specific page for future changes
e.g.) Open compass page for compass tile not just main activity

Change-Id: I9e691b1d508d14d3ff5bcb589e6ff42b8e1a9587